### PR TITLE
Feature/create cli command to generate import statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add pre release building to release workflow on dev/* branches an version changes.
+- feat: Introduced a new CLI command `tsinjex-generate` to automate the generation of import statements for registered dependencies.  
+  The command scans `.ts` files for `@Register` and `@RegisterInstance` decorators and generates an `auto-imports.ts` file.  
+  This ensures that all registered dependencies are automatically included without requiring manual imports.  
+  The CLI can be executed via `npx tsinjex-generate` or added as a script in `package.json` for easier integration.
 
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Deprecated
+
+
+### Removed
+
+
+### Fixed
+
+
+### Security
+
+
+## [0.2.0]
+
+### Added
+
 - Add pre release building to release workflow on dev/* branches an version changes.
 - feat: Introduced a new CLI command `tsinjex-generate` to automate the generation of import statements for registered dependencies.  
   The command scans `.ts` files for `@Register` and `@RegisterInstance` decorators and generates an `auto-imports.ts` file.  
@@ -26,7 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Security
-
 
 ## [0.0.14]
 
@@ -60,3 +76,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [unreleased]: https://github.com/PxaMMaxP/TSinjex/compare/0.0.14...HEAD
 [0.0.14]: https://github.com/PxaMMaxP/TSinjex/compare/0.0.13...v0.0.14
+[0.2.00]: https://github.com/PxaMMaxP/TSinjex/compare/0.0.14...v0.2.0

--- a/bin/generate-imports.cjs
+++ b/bin/generate-imports.cjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const yargs = require('yargs');
+
+// CLI argument parsing
+const argv = yargs
+  .option('src', {
+    alias: 's',
+    type: 'string',
+    description: 'Directory to search for files',
+    default: 'src',
+  })
+  .option('output', {
+    alias: 'o',
+    type: 'string',
+    description: 'Path to the output file',
+    default: 'src/auto-imports.ts',
+  })
+  .option('pattern', {
+    alias: 'p',
+    type: 'string',
+    description: 'File pattern to search for (e.g., .ts, .js)',
+    default: '.ts',
+  })
+  .help()
+  .argv;
+
+// Fixed RegEx patterns for decorator detection
+const SEARCH_PATTERNS = [
+  /^@Register(?:<(.+)?>)?\(\s*["']{1}(.+)?["']{1}\s*,?\s*(true|false)?\s*\)/m, // Matches @Register(...)
+  /^@RegisterInstance(?:<(.+)?>)?\(\s*["']{1}(.+)?["']{1}\s*,?\s*(.+)?\s*\)/m, // Matches @RegisterInstance(...)
+];
+
+const FILE_PATTERN = argv.pattern.startsWith('.') ? argv.pattern : `.${argv.pattern}`; // Ensure the pattern starts with a dot
+
+/**
+ * Recursively searches for all files in a directory matching the specified pattern.
+ * @param {string} dirPath - The directory to search.
+ * @returns {string[]} - List of matching files.
+ */
+function getAllFiles(dirPath) {
+  let files = fs.readdirSync(dirPath);
+  let arrayOfFiles = [];
+
+  files.forEach((file) => {
+    const fullPath = path.join(dirPath, file);
+    if (fs.statSync(fullPath).isDirectory()) {
+      arrayOfFiles = arrayOfFiles.concat(getAllFiles(fullPath));
+    } else if (file.endsWith(FILE_PATTERN)) {
+      arrayOfFiles.push(fullPath);
+    }
+  });
+
+  return arrayOfFiles;
+}
+
+/**
+ * Filters files that contain at least one of the specified regex patterns.
+ * @param {string[]} files - List of files to check.
+ * @returns {string[]} - Files that contain at least one of the specified patterns.
+ */
+function findFilesWithPattern(files) {
+  return files.filter((file) => {
+    const content = fs.readFileSync(file, 'utf8');
+    return SEARCH_PATTERNS.some((pattern) => pattern.test(content));
+  });
+}
+
+/**
+ * Generates an import file containing imports for all found files.
+ * @param {string[]} files - List of relevant files.
+ * @returns {string} - Generated import code.
+ */
+function generateImports(files) {
+  return files.map((file) => `import '${file.replace(/\\/g, '/')}';`).join('\n') + '\n';
+}
+
+/**
+ * Main function that executes the script.
+ */
+function main() {
+  try {
+    const srcDir = path.resolve(process.cwd(), argv.src);
+    const outputFile = path.resolve(process.cwd(), argv.output);
+
+    if (!fs.existsSync(srcDir)) {
+      console.error(`❌ Error: The directory '${srcDir}' does not exist.`);
+      process.exit(1);
+    }
+
+    const allFiles = getAllFiles(srcDir);
+    const filesWithPattern = findFilesWithPattern(allFiles);
+
+    if (filesWithPattern.length === 0) {
+      console.log(`ℹ️ No ${FILE_PATTERN} files found matching the specified decorator patterns.`);
+      return;
+    }
+
+    const importContent = generateImports(filesWithPattern);
+    fs.writeFileSync(outputFile, importContent);
+
+    console.log(`✅ Imports successfully generated: ${outputFile}`);
+  } catch (error) {
+    console.error('❌ An error occurred:', error.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "tsinjex-generate": "./bin/generate-imports.cjs"
+  },
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-injex",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Simple boilerplate code free dependency injection system for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Add CLI command and update documentation

- Updated the version number to 0.2.0 in documentation
- Added new CLI command `tsinjex-generate`
- Updated changelog to reflect the new CLI command
- Introduced a script for generating import statements

### Detailed Description

This pull request introduces a new command-line interface (CLI) command, `tsinjex-generate`, which automates the generation of import statements for registered dependencies. This feature aims to streamline the development process by reducing manual effort required in managing imports.

Additionally, the project version has been updated to 0.2.0 in the documentation, and the changelog has been updated to reflect the introduction of the new CLI command. A supporting script has also been added to facilitate the automated generation of import statements.