### PR TITLE
Feature/integrate register instance in register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Updated test cases to utilize the new mode parameter when registering an instance.
   Disabled specific ESLint rule in Decorators.test.ts for deprecation warnings.
   Added an additional test call to test_RegisterInstanceDecorator with 'instance' mode.
+- refactor: add region tags for overloads in Register.ts
 
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- refactor: consolidate registration decorators
-  Introduced Register decorator to handle class and instance registration in the DI container.
-  Deprecated RegisterInstance in favor of Register, which now internally handles instance registration.
-  Added support for marking dependencies as deprecated with a warning logged upon first resolution.
-  Updated documentation with examples and notes on deprecation.
-- tests: add mode parameter to RegisterInstanceDecorator
-  Introduced a mode parameter to the test_RegisterInstanceDecorator function allowing 'instance' or 'standalone' modes.
-  Updated test cases to utilize the new mode parameter when registering an instance.
-  Disabled specific ESLint rule in Decorators.test.ts for deprecation warnings.
-  Added an additional test call to test_RegisterInstanceDecorator with 'instance' mode.
-- refactor: add region tags for overloads in Register.ts
-
 
 ### Deprecated
 
@@ -33,6 +21,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.3.0]
+
+### Added
+
+- refactor: consolidate registration decorators
+  Introduced Register decorator to handle class and instance registration in the DI container.
+  Deprecated RegisterInstance in favor of Register, which now internally handles instance registration.
+  Added support for marking dependencies as deprecated with a warning logged upon first resolution.
+  Updated documentation with examples and notes on deprecation.
+- tests: add mode parameter to RegisterInstanceDecorator
+  Introduced a mode parameter to the test_RegisterInstanceDecorator function allowing 'instance' or 'standalone' modes.
+  Updated test cases to utilize the new mode parameter when registering an instance.
+  Disabled specific ESLint rule in Decorators.test.ts for deprecation warnings.
+  Added an additional test call to test_RegisterInstanceDecorator with 'instance' mode.
+- refactor: add region tags for overloads in Register.ts
 
 ## [0.2.0]
 
@@ -89,3 +92,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [unreleased]: https://github.com/PxaMMaxP/TSinjex/compare/0.0.14...HEAD
 [0.0.14]: https://github.com/PxaMMaxP/TSinjex/compare/0.0.13...v0.0.14
 [0.2.00]: https://github.com/PxaMMaxP/TSinjex/compare/0.0.14...v0.2.0
+[0.3.00]: https://github.com/PxaMMaxP/TSinjex/compare/0.2.0...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add pre release building to release workflow on dev/* branches an version changes.
+- refactor: consolidate registration decorators
+  Introduced Register decorator to handle class and instance registration in the DI container.
+  Deprecated RegisterInstance in favor of Register, which now internally handles instance registration.
+  Added support for marking dependencies as deprecated with a warning logged upon first resolution.
+  Updated documentation with examples and notes on deprecation.
+- tests: add mode parameter to RegisterInstanceDecorator
+  Introduced a mode parameter to the test_RegisterInstanceDecorator function allowing 'instance' or 'standalone' modes.
+  Updated test cases to utilize the new mode parameter when registering an instance.
+  Disabled specific ESLint rule in Decorators.test.ts for deprecation warnings.
+  Added an additional test call to test_RegisterInstanceDecorator with 'instance' mode.
 
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- refactor: consolidate registration decorators
+  Introduced Register decorator to handle class and instance registration in the DI container.
+  Deprecated RegisterInstance in favor of Register, which now internally handles instance registration.
+  Added support for marking dependencies as deprecated with a warning logged upon first resolution.
+  Updated documentation with examples and notes on deprecation.
+- tests: add mode parameter to RegisterInstanceDecorator
+  Introduced a mode parameter to the test_RegisterInstanceDecorator function allowing 'instance' or 'standalone' modes.
+  Updated test cases to utilize the new mode parameter when registering an instance.
+  Disabled specific ESLint rule in Decorators.test.ts for deprecation warnings.
+  Added an additional test call to test_RegisterInstanceDecorator with 'instance' mode.
+
 
 ### Deprecated
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-injex",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Simple boilerplate code free dependency injection system for TypeScript.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/__tests__/Decorators.spec.ts
+++ b/src/__tests__/Decorators.spec.ts
@@ -282,6 +282,7 @@ export function test_RegisterInstanceDecorator(
     Container: ITSinjex_,
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     registerInstance: Function,
+    mode: 'instance' | 'standalone' = 'standalone',
 ): void {
     describe('RegisterInstance Decorator Tests', () => {
         let container: ITSinjex;
@@ -295,7 +296,10 @@ export function test_RegisterInstanceDecorator(
         });
 
         it('should register an instance of a dependency', () => {
-            @registerInstance('InstanceIdentifier')
+            @registerInstance(
+                'InstanceIdentifier',
+                mode === 'instance' ? 'instance' : undefined,
+            )
             class TestClass {
                 private readonly _dependency!: any;
 
@@ -337,7 +341,10 @@ export function test_RegisterInstanceDecorator(
         });
 
         it('should register an instance of a dependency and get it on set', () => {
-            @registerInstance('InstanceIdentifier')
+            @registerInstance(
+                'InstanceIdentifier',
+                mode === 'instance' ? 'instance' : undefined,
+            )
             class TestClass {
                 private readonly _dependency!: any;
 

--- a/src/__tests__/Decorators.test.ts
+++ b/src/__tests__/Decorators.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import { TSinjex } from 'src/classes/TSinjex';
 import { Inject } from 'src/decorators/Inject';
 import { Register } from 'src/decorators/Register';
@@ -13,3 +14,5 @@ test_InjectDecorator(TSinjex, Inject);
 test_RegisterDecorator(TSinjex, Register);
 
 test_RegisterInstanceDecorator(TSinjex, RegisterInstance);
+
+test_RegisterInstanceDecorator(TSinjex, Register, 'instance');

--- a/src/decorators/Register.ts
+++ b/src/decorators/Register.ts
@@ -2,6 +2,8 @@ import { InitDelegate } from 'src/types/InitDelegate';
 import { TSinjex } from '../classes/TSinjex';
 import { Identifier } from '../types/Identifier';
 
+//#region Overloads
+
 /**
  * A decorator to register a class in the **TSinjex** DI (Dependency Injection) container.
  * @template TargetType The type of the class to be registered.
@@ -101,6 +103,8 @@ export function Register<
     >,
     deprecated?: boolean,
 ): (constructor: TargetType, ...args: unknown[]) => void;
+
+//#endregion Overloads
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 export function Register<

--- a/src/decorators/Register.ts
+++ b/src/decorators/Register.ts
@@ -1,3 +1,4 @@
+import { InitDelegate } from 'src/types/InitDelegate';
 import { TSinjex } from '../classes/TSinjex';
 import { Identifier } from '../types/Identifier';
 
@@ -16,8 +17,131 @@ import { Identifier } from '../types/Identifier';
  *   // ...
  * }
  * ```
+ * @example
+ * ```ts
+ * \@Register('MyClassIdentifier', true)
+ * class MyClass {
+ *   // ...
+ * }
+ * ```
  */
 export function Register<
+    TargetType extends new (...args: unknown[]) => InstanceType<TargetType>,
+>(
+    identifier: Identifier,
+    deprecated?: boolean,
+): (constructor: TargetType, ...args: unknown[]) => void;
+
+/**
+ * A decorator to register an instance of a class in the DI (Dependency Injection) container.
+ * @template TargetType The type of the class whose instance is to be registered.
+ * @param identifier The identifier used to register the instance in the DI container.
+ * @see {@link Identifier} for more information on identifiers.
+ * @param shouldRegister Set to 'instance' to register the instance in the DI container
+ * with an empty constructor.
+ * @param deprecated If true, the dependency is deprecated and a warning
+ * is logged only once upon the first resolution of the dependency.
+ * @returns The decorator function to be applied on the class.
+ * @example
+ * ```ts
+ * \@RegisterInstance('MyClassInstanceIdentifier', 'instance')
+ * class MyClass {
+ *   // ...
+ * }
+ * ```
+ * @example
+ * ```ts
+ * \@RegisterInstance('MyClassInstanceIdentifier', 'instance', true)
+ * class MyClass {
+ *   // ...
+ * }
+ * ```
+ */
+export function Register<
+    TargetType extends new (..._args: unknown[]) => InstanceType<TargetType>,
+>(
+    identifier: Identifier,
+    shouldRegister: 'instance',
+    deprecated?: boolean,
+): (constructor: TargetType, ...args: unknown[]) => void;
+
+/**
+ * A decorator to register an instance of a class in the DI (Dependency Injection) container.
+ * @template TargetType The type of the class whose instance is to be registered.
+ * @param identifier The identifier used to register the instance in the DI container.
+ * @see {@link Identifier} for more information on identifiers.
+ * @param init An optional initializer function which get the constructor of the class
+ * as input and returns an instance of the class.
+ * @param deprecated If true, the dependency is deprecated and a warning
+ * is logged only once upon the first resolution of the dependency.
+ * @see {@link InitDelegate} for more information on initializer functions.
+ * @returns The decorator function to be applied on the class.
+ * @example
+ * ```ts
+ * \@RegisterInstance('MyClassInstanceIdentifier', (constructor) => new constructor())
+ * class MyClass {
+ *   // ...
+ * }
+ * ```
+ * @example
+ * ```ts
+ * \@RegisterInstance('MyClassInstanceIdentifier', (constructor) => new constructor(), true)
+ * class MyClass {
+ *   // ...
+ * }
+ * ```
+ */
+export function Register<
+    TargetType extends new (..._args: unknown[]) => InstanceType<TargetType>,
+>(
+    identifier: Identifier,
+    init?: InitDelegate<
+        TargetType & { new (..._args: unknown[]): InstanceType<TargetType> },
+        InstanceType<TargetType>
+    >,
+    deprecated?: boolean,
+): (constructor: TargetType, ...args: unknown[]) => void;
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+export function Register<
+    TargetType extends new (...args: unknown[]) => InstanceType<TargetType>,
+>(
+    identifier: Identifier,
+    arg1?:
+        | undefined
+        | boolean
+        | InitDelegate<TargetType, InstanceType<TargetType>>
+        | 'instance',
+    arg2?: boolean,
+): (constructor: TargetType, ...args: unknown[]) => void {
+    const deprecated = typeof arg1 === 'boolean' ? arg1 : arg2;
+    const init = typeof arg1 === 'function' ? arg1 : undefined;
+    const shouldRegisterInstance = arg1 === 'instance';
+
+    if (init == undefined && shouldRegisterInstance !== true) {
+        return _register(identifier, deprecated);
+    } else {
+        return _registerInstance(identifier, init, deprecated);
+    }
+}
+
+/**
+ * A decorator to register a class in the **TSinjex** DI (Dependency Injection) container.
+ * @template TargetType The type of the class to be registered.
+ * @param identifier The identifier used to register the class in the DI container.
+ * @see {@link Identifier} for more information on identifiers.
+ * @param deprecated If true, the dependency is deprecated and a warning
+ * is logged only once upon the first resolution of the dependency.
+ * @returns The decorator function to be applied on the class.
+ * @example
+ * ```ts
+ * \@Register('MyClassIdentifier')
+ * class MyClass {
+ *   // ...
+ * }
+ * ```
+ */
+function _register<
     TargetType extends new (...args: unknown[]) => InstanceType<TargetType>,
 >(identifier: Identifier, deprecated?: boolean) {
     return function (constructor: TargetType, ...args: unknown[]): void {
@@ -27,4 +151,112 @@ export function Register<
         // Register the class in the DI container
         diContainer.register(identifier, constructor, deprecated);
     };
+}
+
+/**
+ * A decorator to register an instance of a class in the DI (Dependency Injection) container.
+ * @template TargetType The type of the class whose instance is to be registered.
+ * @param identifier The identifier used to register the instance in the DI container.
+ * @see {@link Identifier} for more information on identifiers.
+ * @param init An optional initializer function which get the constructor of the class
+ * as input and returns an instance of the class.
+ * @param deprecated If true, the dependency is deprecated and a warning
+ * is logged only once upon the first resolution of the dependency.
+ * @see {@link InitDelegate} for more information on initializer functions.
+ * @returns The decorator function to be applied on the class.
+ * @example
+ * ```ts
+ * \@RegisterInstance('MyClassInstanceIdentifier', (constructor) => new constructor())
+ * class MyClass {
+ *   // ...
+ * }
+ * ```
+ */
+function _registerInstance<
+    TargetType extends new (..._args: unknown[]) => InstanceType<TargetType>,
+>(
+    identifier: Identifier,
+    init?: InitDelegate<
+        TargetType & { new (..._args: unknown[]): InstanceType<TargetType> },
+        InstanceType<TargetType>
+    >,
+    deprecated?: boolean,
+) {
+    return function (constructor: TargetType, ...args: unknown[]): void {
+        // Get the instance of the DI container
+        const diContainer = TSinjex.getInstance();
+        let instance: InstanceType<TargetType>;
+
+        // Create a proxy to instantiate the class when needed (Lazy Initialization)
+        let lazyProxy: unknown = new Proxy(
+            {},
+            {
+                get(target, prop, receiver) {
+                    ({ instance, lazyProxy } = initializeInstance<TargetType>(
+                        instance,
+                        init,
+                        constructor,
+                        args,
+                        lazyProxy,
+                    ));
+
+                    // Return the requested property of the instance
+                    return instance[prop as keyof InstanceType<TargetType>];
+                },
+                set(target, prop, value, receiver) {
+                    ({ instance, lazyProxy } = initializeInstance<TargetType>(
+                        instance,
+                        init,
+                        constructor,
+                        args,
+                        lazyProxy,
+                    ));
+
+                    // Set the requested property of the instance
+                    return (instance[prop as keyof InstanceType<TargetType>] =
+                        value);
+                },
+            },
+        );
+
+        // Register the lazy proxy in the DI container
+        diContainer.register(identifier, lazyProxy, deprecated);
+    };
+}
+
+/**
+ * Initializes the instance of the class.
+ * @template TargetType The type of the class whose instance is to be initialized.
+ * @param instance The instance of the class to be initialized.
+ * @param init The optional initializer function to initialize the instance.
+ * @param constructor The constructor of the class.
+ * @param args The arguments to be passed to the constructor of the class.
+ * @param lazyProxy The lazy proxy to instantiate the class when needed.
+ * @returns The initialized instance and the lazy proxy.
+ */
+function initializeInstance<
+    TargetType extends new (..._args: unknown[]) => InstanceType<TargetType>,
+>(
+    instance: InstanceType<TargetType>,
+    init:
+        | InitDelegate<
+              TargetType &
+                  (new (..._args: unknown[]) => InstanceType<TargetType>),
+              InstanceType<TargetType>
+          >
+        | undefined,
+    constructor: TargetType,
+    args: unknown[],
+    lazyProxy: unknown,
+): { instance: InstanceType<TargetType>; lazyProxy: unknown } {
+    if (instance == null) {
+        if (init) {
+            instance = init(constructor);
+        } else {
+            instance = new constructor(...args);
+        }
+    }
+    lazyProxy = instance;
+
+    return { instance, lazyProxy };
 }


### PR DESCRIPTION
- Merged `feature/integrate-register-instance-in-register` branch.
- Added `mode` parameter to `test_RegisterInstanceDecorator`.
- Consolidated registration decorators into a single `Register` decorator.
- Deprecated `RegisterInstance` in favor of the new `Register` decorator.
- Updated tests to use the new `mode` parameter.
- Updated documentation with examples and deprecation notes.

This pull request merges the `feature/integrate-register-instance-in-register` branch, introducing significant changes to the registration process in the DI container. The `Register` decorator now handles both class and instance registration, deprecating the previous `RegisterInstance` decorator. The change streamlines the registration process and adds support for marking dependencies as deprecated with a warning logged upon first resolution.

Additionally, tests have been updated with a new `mode` parameter to the `test_RegisterInstanceDecorator`, allowing for 'instance' or 'standalone' modes. Documentation has been revised to reflect these changes, including examples and notes on deprecation.